### PR TITLE
Handle code block without langauge specified

### DIFF
--- a/lua/jira/utils.lua
+++ b/lua/jira/utils.lua
@@ -57,7 +57,8 @@ function Utils.adf_to_markdown(adt)
 
 		local top_level_block_nodes_to_markdown = {
 			codeBlock = function(node)
-				node_md = "```" .. node.attrs.language .. "\n"
+				local language = node.attrs.language or ""
+				node_md = "```" .. language .. "\n"
 				for _, v in ipairs(node.content) do
 					node_md = node_md .. adf_node_to_markdown(v)
 				end


### PR DESCRIPTION
The `language` attribute is `nil` if there's no language specified. This results in the following error:

```
Error executing vim.schedule lua callback: ...holy/.local/share/nvim/lazy/jira.nvim/lua/jira/utils.lua:60: attempt to concatenate field 'language' (a nil value)
stack traceback:
        ...holy/.local/share/nvim/lazy/jira.nvim/lua/jira/utils.lua:60: in function <...holy/.local/share/nvim/lazy/jira.nvim/lua/jira/utils.lua:59>
        ...holy/.local/share/nvim/lazy/jira.nvim/lua/jira/utils.lua:250: in function 'adf_node_to_markdown'
        ...holy/.local/share/nvim/lazy/jira.nvim/lua/jira/utils.lua:265: in function 'adf_to_markdown'
        /home/icholy/.config/nvim/init.lua:749: in function 'format'
        ...choly/.local/share/nvim/lazy/jira.nvim/lua/jira/init.lua:92: in function <...choly/.local/share/nvim/lazy/jira.nvim/lua/jira/init.lua:86>
```