### PR TITLE
Handle nodes with no content

### DIFF
--- a/lua/jira/utils.lua
+++ b/lua/jira/utils.lua
@@ -245,15 +245,14 @@ function Utils.adf_to_markdown(adt)
 			end,
 		}
 
+		if not adf_node.content then
+			adf_node.content = {}
+		end
 		if inline_nodes[adf_node.type] then
 			node_md = node_md .. inline_nodes_to_markdown[adf_node.type](adf_node)
 		elseif top_level_block_nodes_to_markdown[adf_node.type] then
 			node_md = node_md .. top_level_block_nodes_to_markdown[adf_node.type](adf_node)
 		else
-			if not adf_node.content then
-				print("Unknown node type: " .. adf_node.type)
-				return node_md
-			end
 			node_md = ""
 			for _, v in ipairs(adf_node.content) do
 				node_md = node_md .. adf_node_to_markdown(v)


### PR DESCRIPTION
I have a paragraph node with no contents that's resulting the following error:

```
Error executing vim.schedule lua callback: ...holy/.local/share/nvim/lazy/jira.nvim/lua/jira/utils.lua:94: bad argument #1 to 'ipairs' (table expected, got nil)
stack traceback:
        [C]: in function 'ipairs'
        ...holy/.local/share/nvim/lazy/jira.nvim/lua/jira/utils.lua:94: in function <...holy/.local/share/nvim/lazy/jira.nvim/lua/jira/utils.lua:92>
        ...holy/.local/share/nvim/lazy/jira.nvim/lua/jira/utils.lua:251: in function 'adf_node_to_markdown'
        ...holy/.local/share/nvim/lazy/jira.nvim/lua/jira/utils.lua:266: in function 'adf_to_markdown'
        /home/icholy/.config/nvim/init.lua:750: in function 'format'
        ...choly/.local/share/nvim/lazy/jira.nvim/lua/jira/init.lua:92: in function <...choly/.local/share/nvim/lazy/jira.nvim/lua/jira/init.lua:86>
```
